### PR TITLE
Lower ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ language: ruby
 cache: bundler
 matrix:
   include:
-  - rvm: jruby-9.1.13.0
+  - rvm: jruby-9.1.12.0
     env: LOGSTASH_BRANCH=master
-  - rvm: jruby-9.1.13.0
+  - rvm: jruby-9.1.12.0
     env: LOGSTASH_BRANCH=6.x
-  - rvm: jruby-9.1.13.0
+  - rvm: jruby-9.1.12.0
     env: LOGSTASH_BRANCH=6.0
   - rvm: jruby-1.7.27
     env: LOGSTASH_BRANCH=5.6


### PR DESCRIPTION
Logstash's ruby version was downgrade, due to some bug and inconsistancies
https://github.com/elastic/logstash/commit/d2cde417d9dd0151c9d1b1dad050a38b14a18c6f
It is applicable on all Logstash 6.x versions, passing from version jruby-9.1.13.0 to jruby-9.1.12.0
